### PR TITLE
fix: Set root path (#3475)

### DIFF
--- a/cmd/argocd/commands/login.go
+++ b/cmd/argocd/commands/login.go
@@ -6,6 +6,7 @@ import (
 	"net/http"
 	"os"
 	"strconv"
+	"strings"
 	"time"
 
 	"github.com/coreos/go-oidc"
@@ -64,11 +65,12 @@ func NewLoginCommand(globalClientOpts *argocdclient.ClientOptions) *cobra.Comman
 				}
 			}
 			clientOpts := argocdclient.ClientOptions{
-				ConfigPath: "",
-				ServerAddr: server,
-				Insecure:   globalClientOpts.Insecure,
-				PlainText:  globalClientOpts.PlainText,
-				GRPCWeb:    globalClientOpts.GRPCWeb,
+				ConfigPath:      "",
+				ServerAddr:      server,
+				Insecure:        globalClientOpts.Insecure,
+				PlainText:       globalClientOpts.PlainText,
+				GRPCWeb:         globalClientOpts.GRPCWeb,
+				GRPCWebRootPath: globalClientOpts.GRPCWebRootPath,
 			}
 			acdClient := argocdclient.NewClientOrDie(&clientOpts)
 			setConn, setIf := acdClient.NewSettingsClientOrDie()
@@ -76,6 +78,10 @@ func NewLoginCommand(globalClientOpts *argocdclient.ClientOptions) *cobra.Comman
 
 			if ctxName == "" {
 				ctxName = server
+				if globalClientOpts.GRPCWebRootPath != "" {
+					rootPath := strings.TrimRight(strings.TrimLeft(globalClientOpts.GRPCWebRootPath, "/"), "/")
+					ctxName = fmt.Sprintf("%s/%s", server, rootPath)
+				}
 			}
 
 			// Perform the login
@@ -110,10 +116,11 @@ func NewLoginCommand(globalClientOpts *argocdclient.ClientOptions) *cobra.Comman
 				localCfg = &localconfig.LocalConfig{}
 			}
 			localCfg.UpsertServer(localconfig.Server{
-				Server:    server,
-				PlainText: globalClientOpts.PlainText,
-				Insecure:  globalClientOpts.Insecure,
-				GRPCWeb:   globalClientOpts.GRPCWeb,
+				Server:          server,
+				PlainText:       globalClientOpts.PlainText,
+				Insecure:        globalClientOpts.Insecure,
+				GRPCWeb:         globalClientOpts.GRPCWeb,
+				GRPCWebRootPath: globalClientOpts.GRPCWebRootPath,
 			})
 			localCfg.UpsertUser(localconfig.User{
 				Name:         ctxName,

--- a/cmd/argocd/commands/relogin.go
+++ b/cmd/argocd/commands/relogin.go
@@ -43,11 +43,12 @@ func NewReloginCommand(globalClientOpts *argocdclient.ClientOptions) *cobra.Comm
 			var tokenString string
 			var refreshToken string
 			clientOpts := argocdclient.ClientOptions{
-				ConfigPath: "",
-				ServerAddr: configCtx.Server.Server,
-				Insecure:   configCtx.Server.Insecure,
-				GRPCWeb:    globalClientOpts.GRPCWeb,
-				PlainText:  configCtx.Server.PlainText,
+				ConfigPath:      "",
+				ServerAddr:      configCtx.Server.Server,
+				Insecure:        configCtx.Server.Insecure,
+				GRPCWeb:         globalClientOpts.GRPCWeb,
+				GRPCWebRootPath: globalClientOpts.GRPCWebRootPath,
+				PlainText:       configCtx.Server.PlainText,
 			}
 			acdClient := argocdclient.NewClientOrDie(&clientOpts)
 			claims, err := configCtx.User.Claims()

--- a/cmd/argocd/commands/root.go
+++ b/cmd/argocd/commands/root.go
@@ -59,6 +59,7 @@ func NewCommand() *cobra.Command {
 	command.PersistentFlags().StringVar(&clientOpts.CertFile, "server-crt", config.GetFlag("server-crt", ""), "Server certificate file")
 	command.PersistentFlags().StringVar(&clientOpts.AuthToken, "auth-token", config.GetFlag("auth-token", ""), "Authentication token")
 	command.PersistentFlags().BoolVar(&clientOpts.GRPCWeb, "grpc-web", config.GetBoolFlag("grpc-web"), "Enables gRPC-web protocol. Useful if Argo CD server is behind proxy which does not support HTTP2.")
+	command.PersistentFlags().StringVar(&clientOpts.GRPCWebRootPath, "grpc-web-root-path", config.GetFlag("grpc-web-root-path", ""), "Enables gRPC-web protocol. Useful if Argo CD server is behind proxy which does not support HTTP2. Set web root.")
 	command.PersistentFlags().StringVar(&logLevel, "loglevel", config.GetFlag("loglevel", "info"), "Set the logging level. One of: debug|info|warn|error")
 	command.PersistentFlags().StringSliceVarP(&clientOpts.Headers, "header", "H", []string{}, "Sets additional header to all requests made by Argo CD CLI. (Can be repeated multiple times to add multiple headers, also supports comma separated headers)")
 	command.PersistentFlags().BoolVar(&clientOpts.PortForward, "port-forward", config.GetBoolFlag("port-forward"), "Connect to a random argocd-server port using port forwarding")

--- a/pkg/apiclient/grpcproxy.go
+++ b/pkg/apiclient/grpcproxy.go
@@ -55,7 +55,8 @@ func (c *client) executeRequest(fullMethodName string, msg []byte, md metadata.M
 	if c.PlainText {
 		schema = "http"
 	}
-	req, err := http.NewRequest(http.MethodPost, fmt.Sprintf("%s://%s%s", schema, c.ServerAddr, fullMethodName), bytes.NewReader(toFrame(msg)))
+	rootPath := strings.TrimRight(strings.TrimLeft(c.GRPCWebRootPath, "/"), "/")
+	req, err := http.NewRequest(http.MethodPost, fmt.Sprintf("%s://%s/%s%s", schema, c.ServerAddr, rootPath, fullMethodName), bytes.NewReader(toFrame(msg)))
 	if err != nil {
 		return nil, err
 	}

--- a/util/localconfig/localconfig.go
+++ b/util/localconfig/localconfig.go
@@ -41,6 +41,8 @@ type Server struct {
 	Insecure bool `json:"insecure,omitempty"`
 	// GRPCWeb indicates to connect to the server using gRPC Web protocol
 	GRPCWeb bool `json:"grpc-web,omitempty"`
+	// GRPCWebRootPath indicates to connect to the server using gRPC Web protocol with this root path
+	GRPCWebRootPath string `json:"grpc-web-root-path"`
 	// CACertificateAuthorityData is the base64 string of a PEM encoded certificate
 	// TODO: not yet implemented
 	CACertificateAuthorityData string `json:"certificate-authority-data,omitempty"`


### PR DESCRIPTION
* Set root path

* updated http mux if --rootpath is set during server startup.
updated baseHRef if --rootpath is set.
added --grpc-web-root-path for CLI.

* added rootpath as part of config context name

* clean up not used variables.

Checklist:

* [ ] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-cd/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this does not need to be in the release notes.
* [ ] The title of the PR states what changed and the related issues number (used for the release note).
* [ ] I've updated both the CLI and UI to expose my feature, or I plan to submit a second PR with them.
* [ ] Optional. My organization is added to USERS.md.
* [ ] I've signed the CLA and my build is green ([troubleshooting builds](https://argoproj.github.io/argo-cd/developer-guide/ci/)). 
